### PR TITLE
Move PWA assets into public directory for static delivery

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -25,49 +25,49 @@
         }
     ],
     "splash": {
-        "640x1136":  "public/img/pwa/splash-640x1136.png",
-        "750x1334":  "public/img/pwa/splash-750x1334.png",
-        "828x1792":  "public/img/pwa/splash-828x1792.png",
-        "1125x2436": "public/img/pwa/splash-1125x2436.png",
-        "1242x2208": "public/img/pwa/splash-1242x2208.png",
-        "1242x2688": "public/img/pwa/splash-1242x2688.png",
-        "1536x2048": "public/img/pwa/splash-1536x2048.png",
-        "1668x2224": "public/img/pwa/splash-1668x2224.png",
-        "1668x2388": "public/img/pwa/splash-1668x2388.png",
-        "2048x2732": "public/img/pwa/splash-2048x2732.png"
+        "640x1136":  "img/pwa/splash-640x1136.png",
+        "750x1334":  "img/pwa/splash-750x1334.png",
+        "828x1792":  "img/pwa/splash-828x1792.png",
+        "1125x2436": "img/pwa/splash-1125x2436.png",
+        "1242x2208": "img/pwa/splash-1242x2208.png",
+        "1242x2688": "img/pwa/splash-1242x2688.png",
+        "1536x2048": "img/pwa/splash-1536x2048.png",
+        "1668x2224": "img/pwa/splash-1668x2224.png",
+        "1668x2388": "img/pwa/splash-1668x2388.png",
+        "2048x2732": "img/pwa/splash-2048x2732.png"
     },
     "icons": [
         {
-            "src": "public/img/pwa/icon-192x192.png",
+            "src": "img/pwa/icon-192x192.png",
             "type": "image/png",
             "sizes": "192x192"
         },
         {
             "purpose": "maskable",
-            "src": "public/img/pwa/icon-192x192-maskable.png",
+            "src": "img/pwa/icon-192x192-maskable.png",
             "type": "image/png",
             "sizes": "192x192"
         },
         {
-            "src": "public/img/pwa/icon-512x512.png",
+            "src": "img/pwa/icon-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         },
         {
             "purpose": "maskable",
-            "src": "public/img/pwa/icon-512x512-maskable.png",
+            "src": "img/pwa/icon-512x512-maskable.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
     "screenshots": [
         {
-            "src": "public/img/pwa/screenshot-dashboard.png",
+            "src": "img/pwa/screenshot-dashboard.png",
             "sizes": "1932x1394",
             "type": "image/png"
         },
         {
-            "src": "public/img/pwa/screenshot-invoice.png",
+            "src": "img/pwa/screenshot-invoice.png",
             "sizes": "2748x1986",
             "type": "image/png"
         }
@@ -80,7 +80,7 @@
             "url": "sales/invoices/create?utm_source=pwa",
             "icons": [
                 {
-                    "src": "public/img/pwa/icon-192x192.png",
+                    "src": "img/pwa/icon-192x192.png",
 					"sizes": "192x192"
                 }
             ]
@@ -92,7 +92,7 @@
             "url": "banking/transactions/create?type=income&utm_source=pwa",
             "icons": [
                 {
-                    "src": "public/img/pwa/icon-192x192.png",
+                    "src": "img/pwa/icon-192x192.png",
 					"sizes": "192x192"
                 }
             ]
@@ -104,7 +104,7 @@
             "url": "purchases/bills/create?utm_source=pwa",
             "icons": [
                 {
-                    "src": "public/img/pwa/icon-192x192.png",
+                    "src": "img/pwa/icon-192x192.png",
 					"sizes": "192x192"
                 }
             ]
@@ -116,7 +116,7 @@
             "url": "banking/transactions/create?type=expense&utm_source=pwa",
             "icons": [
                 {
-                    "src": "public/img/pwa/icon-192x192.png",
+                    "src": "img/pwa/icon-192x192.png",
 					"sizes": "192x192"
                 }
             ]

--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -1,7 +1,7 @@
 var staticCacheName = "pwa-v" + new Date().getTime();
 var filesToCache = [
-    'public/img/pwa/icon-192x192.png',
-    'public/img/pwa/icon-512x512.png'
+    'img/pwa/icon-192x192.png',
+    'img/pwa/icon-512x512.png'
 ];
 
 /*

--- a/resources/views/components/layouts/pwa/head.blade.php
+++ b/resources/views/components/layouts/pwa/head.blade.php
@@ -7,27 +7,27 @@
 <!-- Add to homescreen for Chrome on Android -->
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="application-name" content="{{ config('app.name') }}">
-<link rel="icon" sizes="512x512" href="{{ asset('public/img/pwa/icon-512x512.png') }}">
+<link rel="icon" sizes="512x512" href="{{ asset('img/pwa/icon-512x512.png') }}">
 
 <!-- Add to homescreen for Safari on iOS -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="#ffffff">
 <meta name="apple-mobile-web-app-title" content="{{ config('app.name') }}">
-<link rel="apple-touch-icon" href="{{ asset('public/img/pwa/icon-512x512.png') }}">
+<link rel="apple-touch-icon" href="{{ asset('img/pwa/icon-512x512.png') }}">
 
-<link href="{{ asset('public/img/pwa/splash-640x1136.png') }}" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-750x1334.png') }}" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-828x1792.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1242x2208.png') }}" media="(device-width: 621px) and (device-height: 1104px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1242x2688.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1536x2048.png') }}" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1668x2224.png') }}" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1668x2388.png') }}" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-2048x2732.png') }}" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-640x1136.png') }}" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-750x1334.png') }}" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-828x1792.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1242x2208.png') }}" media="(device-width: 621px) and (device-height: 1104px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1242x2688.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1536x2048.png') }}" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1668x2224.png') }}" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1668x2388.png') }}" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-2048x2732.png') }}" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
 
 <!-- Tile for Win8 -->
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="{{ asset('public/img/pwa/icon-512x512.png') }}">
+<meta name="msapplication-TileImage" content="{{ asset('img/pwa/icon-512x512.png') }}">
 
 <script type="text/javascript">
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- Move `manifest.json` and `serviceworker.js` to `public/`
- Update internal and template references to use `img/pwa/` paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689da2cceb5c832383afddf49eabe9eb