### PR TITLE
Fix plan limit caching to avoid stale warnings

### DIFF
--- a/app/Traits/Plans.php
+++ b/app/Traits/Plans.php
@@ -89,14 +89,18 @@ trait Plans
     {
         $key = 'plans.limits';
 
-        return Cache::remember($key, Date::now()->addHour(), function () {
-            $url = 'plans/limits';
+        if (Cache::has($key)) {
+            return Cache::get($key);
+        }
 
-            if (! $data = static::getResponseData('GET', $url, ['timeout' => 10])) {
-                return false;
-            }
+        $url = 'plans/limits';
 
-            return $data;
-        });
+        if (! $data = static::getResponseData('GET', $url, ['timeout' => 10])) {
+            return false;
+        }
+
+        Cache::put($key, $data, Date::now()->addHour());
+
+        return $data;
     }
 }

--- a/tests/Fakes/FakePlanLimits.php
+++ b/tests/Fakes/FakePlanLimits.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fakes;
+
+use App\Http\ViewComposers\PlanLimits as BasePlanLimits;
+
+class FakePlanLimits extends BasePlanLimits
+{
+    /**
+     * @var array<int, mixed>
+     */
+    public static array $responses = [];
+
+    public static function getResponseData($method, $path, $data = [], $status_code = 200)
+    {
+        return array_shift(static::$responses);
+    }
+}

--- a/tests/Feature/PlanLimitsTest.php
+++ b/tests/Feature/PlanLimitsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Support\Facades\Cache;
+use Tests\Fakes\FakePlanLimits;
 
 class PlanLimitsTest extends FeatureTestCase
 {
@@ -43,6 +44,44 @@ class PlanLimitsTest extends FeatureTestCase
             ->get(route('invoices.create'))
             ->assertOk()
             ->assertSee('Could not verify plan limit for invoice');
+    }
+
+    public function testWarningsAreClearedAfterSuccessfulFetch()
+    {
+        config(['app.env' => 'local']);
+
+        app()->bind(\App\Http\ViewComposers\PlanLimits::class, FakePlanLimits::class);
+
+        FakePlanLimits::$responses = [false, $this->planLimitsData()];
+
+        $this->loginAs()
+            ->get(route('users.create'))
+            ->assertOk()
+            ->assertSee('Could not verify plan limit for user');
+
+        $this->loginAs()
+            ->get(route('users.create'))
+            ->assertOk()
+            ->assertDontSee('Could not verify plan limit for user');
+
+        $this->loginAs()
+            ->get(route('companies.create'))
+            ->assertOk()
+            ->assertDontSee('Could not verify plan limit for company');
+
+        $this->loginAs()
+            ->get(route('invoices.create'))
+            ->assertOk()
+            ->assertDontSee('Could not verify plan limit for invoice');
+    }
+
+    protected function planLimitsData(): object
+    {
+        return (object) [
+            'user' => (object) ['action_status' => true, 'view_status' => true, 'message' => 'Success'],
+            'company' => (object) ['action_status' => true, 'view_status' => true, 'message' => 'Success'],
+            'invoice' => (object) ['action_status' => true, 'view_status' => true, 'message' => 'Success'],
+        ];
     }
 }
 


### PR DESCRIPTION
## Summary
- Cache plan limits only when remote call succeeds
- Add FakePlanLimits composer and regression test to ensure warnings clear after a successful fetch

## Testing
- `./vendor/bin/phpunit tests/Feature/PlanLimitsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689dc48baafc832390b85a3fe9d264a5