### PR TITLE
Move upload link to modules home page

### DIFF
--- a/resources/views/modules/home/index.blade.php
+++ b/resources/views/modules/home/index.blade.php
@@ -7,6 +7,9 @@
         <x-link href="{{ route('apps.my.index') }}">
             {{ trans('modules.my_apps') }}
         </x-link>
+        <x-link href="{{ route('apps.upload.form') }}">
+            {{ trans('modules.upload_title') }}
+        </x-link>
     </x-slot>
 
     <x-slot name="content">

--- a/resources/views/modules/my/index.blade.php
+++ b/resources/views/modules/my/index.blade.php
@@ -7,9 +7,6 @@
         <x-link href="{{ route('apps.my.index') }}">
             {{ trans('modules.my_apps') }}
         </x-link>
-        <x-link href="{{ route('apps.upload.form') }}">
-            {{ trans('modules.upload_title') }}
-        </x-link>
     </x-slot>
 
     <x-slot name="content">


### PR DESCRIPTION
## Summary
- move app upload link from "My Apps" page to home page
- confirm admin route `apps.upload.form` remains protected by `permission:create-modules-item`

## Testing
- `composer install --no-interaction --no-progress --no-scripts` (fails: brianium/paratest requires php ~8.1.0 || ~8.2.0 || ~8.3.0)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689e15d8424483238eb7805da80bd3d8