### PR TITLE
Honor invitation flag before dispatch

### DIFF
--- a/app/Jobs/Auth/CreateUser.php
+++ b/app/Jobs/Auth/CreateUser.php
@@ -77,7 +77,7 @@ class CreateUser extends Job implements HasOwner, HasSource, ShouldCreate
                 ]);
             }
 
-            if ($this->shouldSendInvitation()) {
+            if ($this->request->boolean('send_invitation') && $this->shouldSendInvitation()) {
                 $this->dispatch(new CreateInvitation($this->model));
             }
         });
@@ -110,10 +110,6 @@ class CreateUser extends Job implements HasOwner, HasSource, ShouldCreate
             return false;
         }
 
-        if (! config('mail.enabled') && ! $this->request->boolean('send_invitation')) {
-            return false;
-        }
-
-        return true;
+        return $this->request->boolean('send_invitation') && config('mail.enabled');
     }
 }


### PR DESCRIPTION
## Summary
- ensure user invitations only send when both request flag and mail config are enabled
- skip CreateInvitation dispatch when checkbox is unchecked

## Testing
- `vendor/bin/phpunit` *(fails: deprecations and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e1603e6f8832395248a9b55f8cbe3