### PR TITLE
Simplify My modules view to show installed modules only

### DIFF
--- a/app/Http/Controllers/Modules/My.php
+++ b/app/Http/Controllers/Modules/My.php
@@ -16,9 +16,8 @@ class My extends Controller
      */
     public function index()
     {
-        $purchase = $this->getMyModules(['query' => ['limit' => 16]]);
         $installed = $this->getInstalledModules();
 
-        return $this->response('modules.my.index', compact('purchase', 'installed'));
+        return $this->response('modules.my.index', compact('installed'));
     }
 }

--- a/resources/views/modules/my/index.blade.php
+++ b/resources/views/modules/my/index.blade.php
@@ -10,10 +10,8 @@
     </x-slot>
 
     <x-slot name="content">
-        @if (! empty($purchase) || ! empty($installed))
-            <x-modules.purchased />
-
-            <x-modules.installed />
+        @if (! empty($installed))
+            <x-modules.installed :modules="$installed" />
         @else
             <div class="py-6 font-medium">
                 <div class="flex items-center justify-between mb-5 lg:mb-0">


### PR DESCRIPTION
## Summary
- Simplify `Modules\My` controller to return only installed modules
- Remove purchased modules section and show installed modules or no apps message

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: Tests: 7, Assertions: 9, Failures: 1, Deprecations: 10)*

------
https://chatgpt.com/codex/tasks/task_e_689e2240834c8323a67c7c2d4634fcd8