### PR TITLE
chore(ci): cache composer lock file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
-          key: php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: php-${{ matrix.php }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            php-${{ matrix.php }}-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary
- cache Composer dependencies based on `composer.lock`
- allow partial Composer cache restores

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689e330c75d88323a144930599946db9