### PR TITLE
ci: improve npm setup in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,19 @@ jobs:
       - name: Copy .env
         run: cp .env.testing .env
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache NPM
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: node-${{ hashFiles('package-lock.json') }}
+
       - name: Install NPM
-        run: npm install
+        run: npm ci
 
       - name: Compile assets
         run: npm run production


### PR DESCRIPTION
## Summary
- install Node 20 in tests workflow
- cache NPM dependencies and use `npm ci`

## Testing
- `node -v && npm --version`
- `npm test` *(fails: Missing script "test")*
- `npm ci --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_689e330dc9588323952a9b0bc77c9222