### PR TITLE
Soft delete user invitations on user removal

### DIFF
--- a/app/Models/Auth/User.php
+++ b/app/Models/Auth/User.php
@@ -72,6 +72,13 @@ class User extends Authenticatable implements HasLocalePreference
         });
     }
 
+    protected static function booted()
+    {
+        static::deleting(function ($user) {
+            $user->invitation?->delete();
+        });
+    }
+
     public function companies()
     {
         return $this->belongsToMany('App\Models\Common\Company', 'App\Models\Auth\UserCompany');

--- a/tests/Feature/Auth/UserInvitationSoftDeleteTest.php
+++ b/tests/Feature/Auth/UserInvitationSoftDeleteTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Jobs\Auth\CreateUser;
+use Tests\Feature\FeatureTestCase;
+
+class UserInvitationSoftDeleteTest extends FeatureTestCase
+{
+    public function testInvitationSoftDeletedWhenUserDeleted(): void
+    {
+        $request = user_model_class()::factory()->enabled()->raw();
+        $request['send_invitation'] = 1;
+
+        $user = $this->dispatch(new CreateUser($request));
+
+        $this->loginAs()
+            ->delete(route('users.destroy', $user->id))
+            ->assertOk();
+
+        $this->assertSoftDeleted('user_invitations', ['user_id' => $user->id]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure deleting a user also soft deletes its invitation
- verify user invitations soft delete through new test

## Testing
- ⚠️ `vendor/bin/phpunit tests/Feature/Auth/UsersTest.php --filter testItShouldDeleteUser` *(fails: table user_invitations is empty)*
- ✅ `vendor/bin/phpunit tests/Feature/Auth/UserInvitationSoftDeleteTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689e2f1fb7fc832389b061d1d76180cd