### PR TITLE
Remove modules bar categories and links

### DIFF
--- a/resources/views/components/layouts/modules/bar.blade.php
+++ b/resources/views/components/layouts/modules/bar.blade.php
@@ -1,67 +1,6 @@
 <div class="relative w-full flex flex-col sm:flex-row border-b pt-8 mb-4">
     <div class="flex items-center">
-        <div class="flex flex-row items-center place-center border-r">
-            <button class="flex items-center" id="dropdownButton" data-dropdown-toggle="dropdown">
-                <i class="material-icons w-10 flex items-center aspect-square text-light-gray ltr:pl-2 rtl:pr-2 hover:text-gray-700"> apps_outlined </i>
-            </button>
-
-            <div id="dropdown" data-click-outside-none class="w-full px-0 hidden z-10">
-                <div class="flex flex-col md:flex-row">
-                    <div class="w-full lg:w-6/12 flex flex-col shadow-md bg-white px-4 lg:pl-8 py-8 gap-2 rounded-l-xl">
-                        <h4 class="capitalize font-thin">
-                            {{ trans_choice('general.categories', 1) }}
-                        </h4>
-
-                        <div class="grid grid-cols-2 gap-2">
-                            @foreach ($categories as $slug => $category)
-                                <x-link href="{{ $categoryUrl($slug) }}" class="font-semibold text-sm ltr:pr-4 rtl:pl-4 lg:pr-0 truncate bg-transparent" override="class">
-                                    <x-link.hover>
-                                        {{ $category }}
-                                    </x-link.hover>
-                                </x-link>
-                            @endforeach
-                        </div>
-                    </div>
-
-                    <div class="w-full lg:w-6/12 flex flex-col shadow-md bg-purple-lighter px-4 lg:px-12 py-8 gap-2 rounded-r-xl">
-                        <h4 class="capitalize font-thin mb-2">
-                            {{ trans('modules.popular_this_week') }}
-                        </h4>
-
-                        @if ($popular)
-                            <div class="flex flex-col gap-4">
-                                @foreach ($popular->data as $item)
-                                    <div class="hover:bg-purple-100 rounded-lg">
-                                        <x-link href="{{ route('apps.app.show', $item->slug) }}" class="flex items-center p-2" override="class">
-                                            @foreach ($item->files as $file)
-                                                @if (($file->media_type == 'image') && ($file->pivot->zone == 'thumbnail'))
-                                                    <img src="{{ $file->path_string }}" alt="{{ $item->name }}" class="w-28 h-20 rounded-md object-cover ltr:mr-3 rtl:ml-3" />
-                                                @endif
-                                            @endforeach
-
-                                            <div class="flex flex-col py-1 gap-0">
-                                                <h6 class="text-sm font-bold capitalize">
-                                                    {!! $item->name !!}
-                                                </h6>
-
-                                                <div class="h-12 overflow-hidden">
-                                                    <p class="font-thin text-xs text-left">
-                                                        {!! $item->description !!}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </x-link>
-                                    </div>
-                                @endforeach
-                            </div>
-                        @else
-                        @endif
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="w-8/12 h-full">
+        <div class="w-full h-full">
             <form method="GET" action="{{ url("/" . company_id()) }}/apps/search">
                 <div class="h-full flex items-center pl-2 gap-2">
                     <i class="material-icons text-light-gray">search</i>
@@ -109,29 +48,4 @@
         </div>
     </div>
 
-    <div class="lg:absolute lg:bottom-2.5 ltr:lg:right-0 rtl:lg:left-0 flex flex-row items-end lg:items-center mb-1 divide-x divide-black-400 mt-4 lg:mt-0">
-        <x-link href="{{ route('apps.home.index') }}" class="text-sm font-semibold px-2 sm:mt-0 sm:mb-0 leading-4" override="class">
-            <x-link.hover color="to-black-400">
-                {{ trans('modules.home') }}
-            </x-link.hover>
-        </x-link>
-
-        <x-link href="{{ route('apps.new') }}" class="text-sm font-semibold px-2 sm:mt-0 sm:mb-0 leading-4" override="class">
-            <x-link.hover color="to-black-400">
-                {{ trans('modules.new') }}
-            </x-link.hover>
-        </x-link>
-
-        <x-link href="{{ route('apps.paid') }}" class="text-sm font-semibold px-2 sm:mt-0 sm:mb-0 leading-4" override="class">
-            <x-link.hover color="to-black-400">
-                {{ trans('modules.top_paid') }}
-            </x-link.hover>
-        </x-link>
-
-        <x-link href="{{ route('apps.free') }}" class="text-sm font-semibold px-2 sm:mt-0 sm:mb-0 leading-4" override="class">
-            <x-link.hover color="to-black-400">
-                {{ trans('modules.top_free') }}
-            </x-link.hover>
-        </x-link>
-    </div>
 </div>


### PR DESCRIPTION
## Summary
- remove modules bar category dropdown and bottom link list
- keep search form intact, header buttons still available

## Testing
- `composer install --prefer-dist --no-interaction --no-scripts --no-progress --no-ansi` *(fails: brianium/paratest requires php ~8.1.0 || ~8.2.0 || ~8.3.0, php 8.4.11 installed)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e3bf8052c832380c7da1adf881be5