### PR TITLE
Wrap module upload form in content slot

### DIFF
--- a/resources/views/modules/item/upload.blade.php
+++ b/resources/views/modules/item/upload.blade.php
@@ -1,8 +1,11 @@
 <x-layouts.modules>
     <x-slot name="title">{{ trans('modules.upload_title') }}</x-slot>
-    <x-form method="POST" action="{{ route('apps.upload') }}" enctype="multipart/form-data">
-        <x-form.input.file name="file" accept=".zip" required />
-        <x-button type="submit">{{ trans('modules.upload_install') }}</x-button>
-    </x-form>
+
+    <x-slot name="content">
+        <x-form method="POST" action="{{ route('apps.upload') }}" enctype="multipart/form-data">
+            <x-form.input.file name="file" accept=".zip" required />
+            <x-button type="submit">{{ trans('modules.upload_install') }}</x-button>
+        </x-form>
+    </x-slot>
 </x-layouts.modules>
 


### PR DESCRIPTION
## Summary
- wrap item upload form in content slot so modules layout receives `content`

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e3bf49ef483238cfa447b4874d8ec