### PR TITLE
Translate leftover English text to Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,38 @@
 
 [![Release](https://img.shields.io/github/v/release/akaunting/akaunting?label=release)](https://github.com/akaunting/akaunting/releases)
 
-Online accounting software designed for small businesses and freelancers. Akaunting is built with modern technologies such as Laravel, VueJS, Tailwind, RESTful API etc. Thanks to its modular structure, Akaunting provides an awesome App Store for users and developers.
+Software de contabilidad en línea diseñado para pequeñas empresas y freelancers. Akaunting está construido con tecnologías modernas como Laravel, VueJS, Tailwind, API REST, etc. Gracias a su estructura modular, Akaunting ofrece una increíble tienda de aplicaciones para usuarios y desarrolladores.
 
-## Requirements
+## Requisitos
 
-* PHP 8.1 or higher
-* Database (e.g.: MariaDB, MySQL, PostgreSQL, SQLite)
-* Web Server (eg: Apache, Nginx, IIS)
-* [Other libraries](https://akaunting.com/hc/docs/on-premise/requirements/)
+* PHP 8.1 o superior
+* Base de datos (ej.: MariaDB, MySQL, PostgreSQL, SQLite)
+* Servidor web (ej.: Apache, Nginx, IIS)
+* [Otras librerías](https://akaunting.com/hc/docs/on-premise/requirements/)
 
 ## Framework
 
-uses [Laravel](http://laravel.com), the best existing PHP framework, as the foundation framework and [Module](https://github.com/akaunting/module) package for Apps.
+Utiliza [Laravel](http://laravel.com), el mejor framework PHP existente, como marco base y el paquete [Module](https://github.com/akaunting/module) para las aplicaciones.
 
-## Installation
+## Instalación
 
-* Install [Composer](https://getcomposer.org/download) and [Npm](https://nodejs.org/en/download)
-* Clone the repository: `git clone https://github.com/akaunting/akaunting.git`
-* Install dependencies: `composer install ; npm install ; npm run dev`
-* Install Akaunting:
+* Instala [Composer](https://getcomposer.org/download) y [Npm](https://nodejs.org/en/download)
+* Clona el repositorio: `git clone https://github.com/akaunting/akaunting.git`
+* Instala dependencias: `composer install ; npm install ; npm run dev`
+* Instala Akaunting:
 
 ```bash
 php artisan install --db-name="akaunting" --db-username="root" --db-password="pass" --admin-email="admin@company.com" --admin-password="123456"
 ```
 
-* Create sample data (optional): `php artisan sample-data:seed`
+* Crea datos de ejemplo (opcional): `php artisan sample-data:seed`
 
-## Contributing
+## Contribuir
 
-Please, be very clear on your commit messages and Pull Requests, empty Pull Request messages may be rejected without reason.
+Por favor, sé muy claro en tus mensajes de commit y Pull Requests; los Pull Requests sin mensaje pueden ser rechazados sin motivo.
 
-When contributing code to Akaunting, you must follow the PSR coding standards. The golden rule is: Imitate the existing Akaunting code.
+Al contribuir código a Akaunting, debes seguir los estándares de codificación PSR. La regla de oro es: imita el código existente de Akaunting.
 
+## Traducción
 
-## Translation
-
-If you'd like to contribute translations, please check out our [Crowdin](https://crowdin.com/project/akaunting) project.
+Si deseas contribuir traducciones, visita nuestro proyecto en [Crowdin](https://crowdin.com/project/akaunting).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,14 +1,14 @@
-# Deployment and Localization
+# Despliegue y localización
 
-## Disable Remote Integrations
+## Desactivar integraciones remotas
 
-Administrators can disable outbound connections to the Akaunting API by clearing the `akaunting_api_url` setting. This is useful for local installations or environments without internet access.
+Los administradores pueden deshabilitar las conexiones salientes a la API de Akaunting limpiando el ajuste `akaunting_api_url`. Esto es útil para instalaciones locales o entornos sin acceso a Internet.
 
-Edit your `.env` file and set:
+Edite su archivo `.env` y establezca:
 
 ```
 AKAUNTING_API_URL=
 ```
 
-When this value is empty, the application will skip all requests made through `SiteApi`, effectively disabling remote integrations. The default value is `https://api.akaunting.com/`.
+Cuando este valor está vacío, la aplicación omitirá todas las solicitudes realizadas a través de `SiteApi`, desactivando efectivamente las integraciones remotas. El valor predeterminado es `https://api.akaunting.com/`.
 

--- a/resources/lang/es-MX/footer.php
+++ b/resources/lang/es-MX/footer.php
@@ -3,8 +3,11 @@
 return [
 
     'version'               => 'Versión',
-    'powered'               => 'Powered By Akaunting',
+    'powered'               => 'Impulsado por Akaunting',
     'link'                  => 'https://akaunting.com',
-    'software'              => 'Software de Contabilidad Libre',
+    'software'              => 'Software de contabilidad en línea',
+    'powered_by'            => 'Desarrollado por',
+    'tag_line'              => 'Envía facturas, rastrea gastos y automatiza la contabilidad con Akaunting. :get_started_url',
+    'get_started'           => 'Comenzar',
 
 ];


### PR DESCRIPTION
## Summary
- Translate footer localization for es-MX and add missing strings
- Convert deployment instructions to Spanish
- Translate README to Spanish

## Testing
- `./vendor/bin/phpunit --stop-on-error` *(fails: Call to a member function getTable() on null)*

------
https://chatgpt.com/codex/tasks/task_e_689e444bdb6083239e7889cdeb6aac18