### PR TITLE
Install CustomFields module by default

### DIFF
--- a/database/seeds/Modules.php
+++ b/database/seeds/Modules.php
@@ -37,5 +37,11 @@ class Modules extends Seeder
             'company'   => $company_id,
             'locale'    => session('locale', company($company_id)->locale),
         ]);
+
+        Artisan::call('module:install', [
+            'alias'     => 'custom-fields',
+            'company'   => $company_id,
+            'locale'    => session('locale', company($company_id)->locale),
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- install CustomFields for each company during module seeding

## Testing
- `composer install --no-interaction --no-progress --prefer-dist`
- `composer test` *(fails: PHPUnit run halted during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d327c908323bbc6a18abb33ad7e