### PR TITLE
Add secondary guard for migration path

### DIFF
--- a/vendor/akaunting/laravel-module/src/Migrations/Migrator.php
+++ b/vendor/akaunting/laravel-module/src/Migrations/Migrator.php
@@ -83,6 +83,10 @@ class Migrator
         $migrationPath = GenerateConfigReader::read('migration');
         $path = (is_array($path) && array_key_exists('path', $path)) ? $path['path'] : $migrationPath->getPath();
 
+        if (empty($path)) {
+            return $path;
+        }
+
         return $this->module->getExtraPath($path);
     }
 


### PR DESCRIPTION
## Summary
- ensure `getPath` returns early when migration path resolves to empty

## Testing
- `composer test` *(fails: process timeout after 300s)*

------
https://chatgpt.com/codex/tasks/task_e_68a47d2a25548323bd0d2d95f63f4bd8