### PR TITLE
chore: use node 18 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,9 @@ jobs:
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: ':memory:'
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        - uses: actions/setup-node@v4
+          with:
+            node-version: 18
       - run: npm ci
       - run: npm run production
       - run: vendor/bin/phpunit --testdox


### PR DESCRIPTION
## Summary
- use Node 18 in CI tests workflow to match dependencies

## Testing
- `env PATH="/usr/local/bin:$PATH" npm ci`


------
https://chatgpt.com/codex/tasks/task_e_68a480faa99083238ebfa1d909a03ba0