### PR TITLE
Rename Company seeder to CompanySeeder

### DIFF
--- a/app/Console/Commands/CompanySeed.php
+++ b/app/Console/Commands/CompanySeed.php
@@ -29,7 +29,7 @@ class CompanySeed extends Command
      */
     public function handle()
     {
-        $class_name = $this->input->getOption('class') ?? 'Database\Seeders\Company';
+        $class_name = $this->input->getOption('class') ?? 'Database\Seeders\CompanySeeder';
 
         $class = $this->laravel->make($class_name);
 
@@ -44,7 +44,7 @@ class CompanySeed extends Command
     protected function getOptions()
     {
         return [
-            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\Seeders\Company'],
+            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\Seeders\CompanySeeder'],
         ];
     }
 }

--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 
-class Company extends Seeder
+class CompanySeeder extends Seeder
 {
     /**
      * Run the database seeds.


### PR DESCRIPTION
## Summary
- rename Company seeder file and class to CompanySeeder
- update CompanySeed command default to use new CompanySeeder class

## Testing
- `composer dump-autoload --no-scripts 2>&1 | tail -n 20`
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4873d44a083239a7262a7fa8ed6a7